### PR TITLE
[codex] fix render deploy workflow variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,21 +24,30 @@ jobs:
     timeout-minutes: 15
     environment:
       name: production
-      url: ${{ vars.RENDER_SERVICE_URL }}
 
     steps:
       - name: Trigger Render deploy
         env:
           RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
           RENDER_DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+          RENDER_SERVICE_URL: ${{ vars.RENDER_SERVICE_URL }}
         run: |
           if [ -z "$RENDER_DEPLOY_HOOK_URL" ]; then
             echo "RENDER_DEPLOY_HOOK_URL is not configured" >&2
+            exit 1
+          fi
+          if [ -z "$RENDER_SERVICE_URL" ]; then
+            echo "RENDER_SERVICE_URL is not configured" >&2
             exit 1
           fi
           if [ -z "$RENDER_DEPLOY_SHA" ]; then
             echo "workflow_run.head_sha is not available" >&2
             exit 1
           fi
+          separator='?'
+          case "$RENDER_DEPLOY_HOOK_URL" in
+            *\?*) separator='&' ;;
+          esac
           curl --fail --silent --show-error --max-time 30 --request POST \
-            "${RENDER_DEPLOY_HOOK_URL}?ref=${RENDER_DEPLOY_SHA}"
+            "${RENDER_DEPLOY_HOOK_URL}${separator}ref=${RENDER_DEPLOY_SHA}"
+          echo "Triggered Render deploy for $RENDER_SERVICE_URL at $RENDER_DEPLOY_SHA"


### PR DESCRIPTION
## Summary
- load `RENDER_SERVICE_URL` from the `production` environment variables inside the deploy step
- fail fast if the `production` environment secret or variable is missing
- fix Render deploy hook invocation so `ref` is appended with the correct query separator

## Why
The deploy workflow was failing even though the environment secret was configured. The Render deploy hook URL already contains query parameters, so appending `?ref=` produced an invalid URL and Render returned `404`. This change also makes the `production` environment variable usage explicit at step runtime.

## Validation
- workflow logic reviewed against GitHub Actions variables documentation
- no local tests run because this is a workflow-only change